### PR TITLE
Updated ARC Example entry with fluid items.

### DIFF
--- a/test_guide/en_us/entries/utility/alchemical_reaction_chamber.json
+++ b/test_guide/en_us/entries/utility/alchemical_reaction_chamber.json
@@ -10,7 +10,9 @@
     {
       "type": "crafting_arc",
       "heading": "test",
-      "recipe": "bloodmagic:arc/netherrack_to_sulfer"
+      "recipe": "bloodmagic:arc/netherrack_to_sulfer",
+      "fluid_input": "minecraft:air",
+      "fluid_output": "minecraft:lava_bucket"
     }
   ]
 }


### PR DESCRIPTION
These are to manually add a fluid indicator of some kind.

They accept any item.  I currently plan on using buckets.  If omitted, those slots will be empty.

At this time there are only two recipes that include any fluid input/output.