### PR TITLE
First polishing pass. Various tweaks.

### DIFF
--- a/VT_notes.txt
+++ b/VT_notes.txt
@@ -1,0 +1,39 @@
+general:
+    Most of the pages I added content to will need a formatting pass for things
+    like the text color highlights and possibly some links.
+
+demon_will/demon_will:
+    "In the lore of Blood Magic...inbues its will into the bodies of the dead."
+    What about living mobs, like Endermen and Creepers? Way gets authority, but
+    my interpretation was that it's the imbued will of a demon that causes mobs
+    to be hostile to a player.  "Neutral" mobs are those that are able to
+    resist the effects, but not completely.
+
+demon_will/soul_gem (and others):
+    Thanks to Data Packs and modpacks frequently changing recipes, we may want
+    to avoid mentioning the default ingredients in the text descriptions.  I
+    mean, I did put in the extra effort to make sure this guide will show any
+    altered recipes.
+
+altar/blood_altar:
+    Please mention that the first 1,000 LP you sacrifice will go to an internal
+    "extract" tank.  That has caused a lot of confusion in the past.  "Why is
+    my Blood Altar draining?!"
+    
+    The Altar Pillars do not have to be "solid" blocks.  I think they can be
+    basically anything.  The code says "not air."
+
+altar/redstone_automation:
+    I think this all is NYI.
+
+altar/slates:
+    I think almost all of the text on this page can get nuked.  If that does
+    happen, please make sure you update the "extra_recipe_mappings" at the top
+    of that entry.  The number is which page it should go to when someone tries
+    to find the recipe of that slate, and it starts counting from 0.
+
+I only had time to get through the Demon Will and Blood Altars chapters.  I do
+remember wanting to note something else though...
+
+utility/getting_started:
+    Sentient Sword should be Tier-0.  You do not need a Blood Altar to use it.

--- a/test_guide/en_us/entries/alchemy_array/arcane_ash.json
+++ b/test_guide/en_us/entries/alchemy_array/arcane_ash.json
@@ -2,10 +2,16 @@
   "name": "Alchemy Array Basics",
   "icon": "bloodmagic:arcaneashes",
   "category": "alchemy_array",
+  "extra_recipe_mappings":[["bloodmagic:arcaneashes", 1]],
   "pages": [
     {
       "type": "text",
       "text": "$(item)Arcane Ashes$() is an item that is pivotal in the creation of Alchemy Arrays. $(item)Arcane Ashes$() can be crafted in the $(l:demon_will/soul_forge)Hellfire Forge$(/l) using some early game items. The recipe can be found in JEI."
+    },
+    {
+      "type": "crafting_soulforge",
+      "heading": "Arcane Ashes",
+      "recipe": "bloodmagic:soulforge/arcaneashes"
     },
     {
    	  "type": "text",

--- a/test_guide/en_us/entries/altar/blood_altar.json
+++ b/test_guide/en_us/entries/altar/blood_altar.json
@@ -90,7 +90,7 @@
           ["G_____G", "_______", "_______", "___0___", "_______", "_______", "G_____G"],
           ["P_____P", "_______", "_______", "___A___", "_______", "_______", "P_____P"],
           ["P_____P", "_______", "__RRR__", "__R_R__", "__RRR__", "_______", "P_____P"],
-          ["_RRRRR_", "R_____R", "R_____R", "R_____R", "R_____R", "_______", "_RRRRR_"]
+          ["_RRRRR_", "R_____R", "R_____R", "R_____R", "R_____R", "R_____R", "_RRRRR_"]
         ],
         "mapping":{
           "A": "bloodmagic:altar",
@@ -104,7 +104,7 @@
     },
     {
       "type": "text",
-      "text": "To upgrade the Blood Altar to Tier 4, place 7 $(item) Blood Runes$() one block down and two blocks away from the previous set of runes along each edge. Then place four solid blocks in each corner, starting above the new ring of runes, and then cap each pillar with $(item)Bloodstone Bricks$() and/or $(item)Large Bloodstone Bricks$()."
+      "text": "To upgrade the Blood Altar to Tier 4, place 7 $(item) Blood Runes$() one block down and two blocks away from the previous set of runes along each edge. Then place four solid blocks in each corner, starting above the new ring of runes, and then cap each pillar with $(l:utility/bloodstone_bricks)Bloodstone Bricks$(/l) and/or $(l:utility/bloodstone_bricks)Large Bloodstone Bricks$(/l)."
     },
     {
       "type": "multiblock",

--- a/test_guide/en_us/entries/altar/slates.json
+++ b/test_guide/en_us/entries/altar/slates.json
@@ -2,6 +2,12 @@
   "name": "Tiers of Slates",
   "icon": "bloodmagic:blankslate",
   "category": "altar",
+  "extra_recipe_mappings":[
+    ["bloodmagic:blankslate", 2],
+    ["bloodmagic:reinforcedslate", 2],
+    ["bloodmagic:infusedslate", 3],
+    ["bloodmagic:demonslate", 3]
+  ],
   "pages": [
     {
       "type": "text",

--- a/test_guide/en_us/entries/altar/soul_network.json
+++ b/test_guide/en_us/entries/altar/soul_network.json
@@ -2,6 +2,12 @@
   "name": "Soul Network",
   "icon": "bloodmagic:weakbloodorb",
   "category": "altar",
+  "extra_recipe_mappings":[
+    ["bloodmagic:weakbloodorb", 3],
+    ["bloodmagic:apprenticebloodorb", 3],
+    ["bloodmagic:magicianbloodorb", 4],
+    ["bloodmagic:masterbloodorb", 4]
+  ],
   "pages": [
     {
       "type": "text",
@@ -13,7 +19,7 @@
     },
     {
       "type": "text",
-      "text": "being placed inside of a $(l:altar/blood_altar)Blood Altar$(/l) with LP.$(br2)  There is a separate Blood Orb that can be created for each Tier of the Blood Altar:$(li)$(item)Weak Blood Orb$(), Max capacity: 5000LP.$(li)$(item)Apprentice Blood Orb$(), Max capacity: 25k LP. $(li)$(item)Magician Blood Orb$(), Max capacity: 150k LP.$(li)$(item)Master Blood Orb$(), Max capacity: 1M LP."
+      "text": "being placed inside of a $(l:altar/blood_altar)Blood Altar$(/l) with LP.$(br2)  There is a separate Blood Orb that can be created for each Tier of the Blood Altar:$(li)$(item)Weak Blood Orb$(), Max capacity: 5k LP.$(li)$(item)Apprentice Blood Orb$(), Max capacity: 25k LP. $(li)$(item)Magician Blood Orb$(), Max capacity: 150k LP.$(li)$(item)Master Blood Orb$(), Max capacity: 1M LP."
     },
 	{
       "type": "2x_crafting_altar",

--- a/test_guide/en_us/entries/demon_will/aspected_will.json
+++ b/test_guide/en_us/entries/demon_will/aspected_will.json
@@ -26,7 +26,7 @@
     },
 	{
       "type": "text",
-      "text": "$(steadfast)$(li)Steadfast Will$(): Increases damage (but not as much as $raw()Raw$()) and grants Absorption after a kill. $(destructive)$(li)Destructive Will$(): Increases damage more than any other will type, but increases attack speed more slowly than any other type. Top Tier is still faster than an unempowered tool / equivalent iron tool, but slower than any other will type."
+      "text": "$(steadfast)$(li)Steadfast Will$(): Increases damage (but not as much as $(raw)Raw$()) and grants Absorption after a kill. $(destructive)$(li)Destructive Will$(): Increases damage more than any other will type, but increases attack speed more slowly than any other type. Top Tier is still faster than an unempowered tool / equivalent iron tool, but slower than any other will type."
     },
 	{
       "type": "text",

--- a/test_guide/en_us/entries/demon_will/demon_will.json
+++ b/test_guide/en_us/entries/demon_will/demon_will.json
@@ -2,6 +2,7 @@
   "name": "Demon Will",
   "icon": "bloodmagic:basemonstersoul",
   "category": "demon_will",
+  "extra_recipe_mappings":[["bloodmagic:basemonstersoul", 0]],
   "pages": [
     {
       "type": "text",

--- a/test_guide/en_us/entries/demon_will/soul_gem.json
+++ b/test_guide/en_us/entries/demon_will/soul_gem.json
@@ -2,6 +2,12 @@
   "name": "Tartaric Gems",
   "icon": "bloodmagic:soulgemgreater",
   "category": "demon_will",
+  "extra_recipe_mappings":[
+    ["bloodmagic:soulgempetty", 1],
+    ["bloodmagic:soulgemlesser", 3],
+    ["bloodmagic:soulgemcommon", 5],
+    ["bloodmagic:soulgemgreater", 7]
+  ],
   "pages": [
     {
       "type": "text",

--- a/test_guide/en_us/entries/utility/alchemical_reaction_chamber.json
+++ b/test_guide/en_us/entries/utility/alchemical_reaction_chamber.json
@@ -2,21 +2,106 @@
   "name": "Alchemical Reaction Chamber",
   "icon": "bloodmagic:alchemicalreactionchamber",
   "category": "utility",
+  "extra_recipe_mappings": [["bloodmagic:weakbloodshard", 3]],
   "pages": [
      {
       "type": "text",
-      "text": "The $(item)Alchemical Reaction Chamber$() isn't fully implemented yet, but among other things it can function as a furnace, offers a form of ore-tripling, and is currently the only way to get $(item)Weak Blood Shards$(), specifically from an $(l:altar/slates)Imbued Slate$()."
+      "text": "The $(item)Alchemical Reaction Chamber$() isn't fully implemented yet, but among other things it can function as a furnace, offers a form of ore-tripling, revert Blood Orbs, and is currently the only way to get $(item)Weak Blood Shards$(), specifically from an $(l:altar/slates)Imbued Slate$()."
     },
     {
       "type": "crafting",
       "recipe": "bloodmagic:arc"
     },
     {
+      "type": "crafting_soulforge",
+      "heading": "Sanguine Reverter",
+      "recipe": "bloodmagic:soulforge/sanguine_reverter",
+      "text": "The Sanguine Reverter is used to create Weak Blood Shards, and revert Blood Orbs to their input crafting item."
+    },
+    {
+      "type": "3x_crafting_arc",
+      "a.heading": "Weak Blood Shard",
+      "a.recipe": "bloodmagic:arc/weakbloodshard",
+      "b.heading": "Revert Weak Blood Orb",
+      "b.recipe": "bloodmagic:arc/reversion/weak_blood_orb",
+      "c.heading": "Revert Apprentice Blood Orb",
+      "c.recipe": "bloodmagic:arc/reversion/apprentice_blood_orb"
+    },
+    {
+      "type": "2x_crafting_arc",
+      "a.heading": "Revert Magician Blood Orb",
+      "a.recipe": "bloodmagic:arc/reversion/magician_blood_orb",
+      "b.heading": "Revert Master Blood Orb",
+      "b.recipe": "bloodmagic:arc/reversion/master_blood_orb",
+      "b.text": "Turn the page for more uses of the ARC."
+    },
+    {
+      "type": "empty"
+    },
+    {
+      "type": "crafting_alchemy_table",
+      "heading": "Explosive Powder",
+      "recipe": "bloodmagic:alchemytable/explosive_powder",
+      "text": "Explosive Powder in the ARC is used to turn Ores into Ore Fragments for 3x Ore Processing, or turn Ingots into their Sand variant.  It can also turn Netherrack into Sulfer and 5mb of Lava."
+    },
+    {
+      "type": "3x_crafting_arc",
+      "a.heading": "Ore to 3 Ore Fragments",
+      "a.recipe": "bloodmagic:arc/fragmentsiron",
+      "b.heading": "Ingot to Metal Sand",
+      "b.recipe": "bloodmagic:arc/dustsfrom_ingot_iron",
+      "c.heading": "Sulfur and Lava",
+      "c.recipe": "bloodmagic:arc/netherrack_to_sulfer",
+      "c.fluid_output": "minecraft:lava_bucket"
+    },
+    {
+      "type": "crafting_soulforge",
+      "heading": "Resonator",
+      "recipe": "bloodmagic:soulforge/primitive_crystalline_resonator",
+      "text": "The Resonator is used to turn Ore Fragments into the relevant Gravel for continued ore processing, and creates some tiny dusts that are NYI."
+    },
+    {
       "type": "crafting_arc",
-      "heading": "test",
-      "recipe": "bloodmagic:arc/netherrack_to_sulfer",
-      "fluid_input": "minecraft:air",
-      "fluid_output": "minecraft:lava_bucket"
+      "heading": "Ore Fragment to Metal Gravel",
+      "recipe": "bloodmagic:arc/gravelsiron"
+    },
+    {
+      "type": "crafting_alchemy_table",
+      "heading": "Basic Cutting Fluid",
+      "recipe": "bloodmagic:alchemytable/basic_cutting_fluid",
+      "text": "Cutting Fluid turns a metal's Gravel into that metal's Sand for continued 3x ore processing.  It can also turn an ore directly into two metal Sand for 2x Ore Processing.  The same 2x Ore Processing is possible in the Alchemy Table, but doing it in the ARC will save you some LP."
+    },
+    {
+      "type": "2x_crafting_arc",
+      "a.heading": "Metal Gravel to Metal Sand",
+      "a.recipe": "bloodmagic:arc/dustsfrom_gravel_iron",
+      "b.heading": "Ore to 2 Metal Sand",
+      "b.recipe": "bloodmagic:arc/dustsfrom_ore_iron"
+    },
+    {
+      "type": "crafting",
+      "heading": "Fuel Cell (Furnace)",
+      "recipe": "bloodmagic:primitive_furnace_cell",
+      "text": "The ARC also functions as a Furnace, but the only fuel sources it accepts is the Primative Fuel Cell or $(l:utility/lava_crystal)Lava Crystal$(/l)."
+    },
+    {
+      "type": "text",
+      "text": "The Primitive Fuel Cell is good for 128 individual uses. That's more than the Block of Coal used to craft it (60 items), and since it only loses durability when the crafting is finished it will not wase fuel."
+    },
+    {
+      "type": "crafting",
+      "heading": "Hydration Cell",
+      "recipe": "bloodmagic:primitive_hydration_cell",
+      "text": "The Hydration Cell is used to make Clay, the Cornerstone of Balance."
+    },
+    {
+      "type": "2x_crafting_arc",
+      "a.heading": "Clay from Sand",
+      "a.recipe": "bloodmagic:arc/clay_from_sand",
+      "a.fluid_input": "minecraft:water_bucket",
+      "b.heading": "Clay from Terracotta",
+      "b.recipe": "bloodmagic:arc/clay_from_terracotta",
+      "b.fluid_input": "minecraft:water_bucket"
     }
   ]
 }

--- a/test_guide/en_us/entries/utility/alchemy_table.json
+++ b/test_guide/en_us/entries/utility/alchemy_table.json
@@ -5,28 +5,68 @@
   "pages": [
     {
       "type": "text",
-      "text": "The Alchemy Table takes a little LP and a few ingredients to do some wondrous things! $(br2)Mouse over the LP arrow for more info."
+      "text": "The Alchemy Table takes a little LP and a few ingredients to do some wondrous things!$(br2)A lot of its content is NYI.$(br2)Mouse over the LP arrow for more info."
     },
-	{
+    {
+      "type": "crafting",
+      "recipe": "bloodmagic:alchemy_table"
+    },
+    {
       "type": "crafting_alchemy_table",
+      "heading": "Basic Cutting Fluid",
       "recipe": "bloodmagic:alchemytable/basic_cutting_fluid",
-	  "heading": "Basic Cutting Fluid"
+      "text": "Basic Cutting Fluid is used for 2x Ore Processing.  It is also used in the $(l:utility/alchemical_reaction_chamber)Alchemical Reaction Chamber$(/l) for the same purpose."
     },
     {
       "type": "2x_crafting_alchemy_table",
-	  "a.heading": "Explosive Poweder",
-      "a.recipe": "bloodmagic:alchemytable/explosive_powder",
-      "b.heading": "Flint from Gravel",
-      "b.recipe": "bloodmagic:alchemytable/flint_from_gravel"
+      "a.heading": "Iron Sand",
+      "a.recipe": "bloodmagic:alchemytable/sand_iron",
+      "b.heading": "Gold Sand",
+      "b.recipe": "bloodmagic:alchemytable/sand_gold"
+    },
+    {
+      "type": "text",
+      "text": "The Alchemy Table provides several ways to get vanilla items."
     },
     {
       "type": "3x_crafting_alchemy_table",
-	  "a.heading": "Explosive Poweder",
-      "a.recipe": "bloodmagic:alchemytable/explosive_powder",
-      "b.heading": "Flint from Gravel",
-      "b.recipe": "bloodmagic:alchemytable/flint_from_gravel",
-      "c.heading": "Grass Block",
-      "c.recipe": "bloodmagic:alchemytable/grass_block"
+      "a.heading": "Grass",
+      "a.recipe": "bloodmagic:alchemytable/grass_block",
+      "b.heading": "Leather",
+      "b.recipe": "bloodmagic:alchemytable/leather_from_flesh",
+      "c.heading": "Bread",
+      "c.recipe": "bloodmagic:alchemytable/bread"
+    },
+    {
+      "type": "2x_crafting_alchemy_table",
+      "a.heading": "Clay",
+      "a.recipe": "bloodmagic:alchemytable/clay_from_sand",
+      "b.heading": "String",
+      "b.recipe": "bloodmagic:alchemytable/string"
+    },
+    {
+      "type": "2x_crafting_alchemy_table",
+      "a.heading": "Flint",
+      "a.recipe": "bloodmagic:alchemytable/flint_from_gravel",
+      "b.heading": "Gunpowder",
+      "b.recipe": "bloodmagic:alchemytable/gunpowder",
+      "b.text": "Flint is currently bugged, though a great way to get rid of both Gravel and LP!$(br2)Saltpeter NYI in Blood Magic."
+    },
+    {
+      "type": "3x_crafting_alchemy_table",
+      "a.heading": "Plant Oil",
+      "a.recipe": "bloodmagic:alchemytable/plantoil_from_wheat",
+      "b.recipe": "bloodmagic:alchemytable/plantoil_from_carrots",
+      "c.recipe": "bloodmagic:alchemytable/plantoil_from_taters"
+    },
+    {
+      "type": "3x_crafting_alchemy_table",
+      "a.heading": "Plant Oil Cont.",
+      "a.recipe": "bloodmagic:alchemytable/plantoil_from_beets",
+      "b.heading": "Coal Sand",
+      "b.recipe": "bloodmagic:alchemytable/sand_coal",
+      "c.heading": "Explosive Powder",
+      "c.recipe": "bloodmagic:alchemytable/explosive_powder"
     }
   ]
 }

--- a/test_guide/en_us/entries/utility/bloodstone_bricks.json
+++ b/test_guide/en_us/entries/utility/bloodstone_bricks.json
@@ -1,0 +1,16 @@
+{
+  "name": "Bloodstone Bricks",
+  "icon": "bloodmagic:largebloodstonebrick",
+  "category": "utility",
+  "pages":[
+    {
+      "type": "text",
+      "text": "Bloodstone Bricks are a decorational block, and used as the capstones for the Tier-4 Blood Altar."
+    },
+    {
+      "type": "crafting",
+      "recipe": "bloodmagic:largebloodstonebrick",
+      "recipe2": "bloodmagic:bloodstonebrick"
+    }
+  ]
+}

--- a/test_guide/en_us/templates/2x_crafting_arc.json
+++ b/test_guide/en_us/templates/2x_crafting_arc.json
@@ -1,0 +1,16 @@
+{
+  "include": [
+    {
+      "template": "crafting_arc",
+      "as": "a",
+      "x": 0,
+      "y": 0
+    },
+    {
+      "template": "crafting_arc",
+      "as": "b",
+      "x": 0,
+      "y": 53
+    }
+  ]
+}

--- a/test_guide/en_us/templates/3x_crafting_arc.json
+++ b/test_guide/en_us/templates/3x_crafting_arc.json
@@ -1,0 +1,22 @@
+{
+  "include": [
+    {
+      "template": "crafting_arc",
+      "as": "a",
+      "x": 0,
+      "y": 0
+    },
+    {
+      "template": "crafting_arc",
+      "as": "b",
+      "x": 0,
+      "y": 53
+    },
+    {
+      "template": "crafting_arc",
+      "as": "c",
+      "x": 0,
+      "y": 106
+    }
+  ]
+}

--- a/test_guide/en_us/templates/crafting_alchemy_table.json
+++ b/test_guide/en_us/templates/crafting_alchemy_table.json
@@ -8,6 +8,12 @@
       "y": -6
     },
     {
+      "type": "text",
+      "text": "#text",
+      "x": 0,
+      "y": 51
+    },
+    {
       "type": "image",
       "image": "bloodmagic:textures/gui/patchouli_book/crafting.png",
       "x": 2,

--- a/test_guide/en_us/templates/crafting_altar.json
+++ b/test_guide/en_us/templates/crafting_altar.json
@@ -21,6 +21,12 @@
     },
     {
       "type": "item",
+      "item": "bloodmagic:altar",
+      "x": 87,
+      "y": 46
+    },
+    {
+      "type": "item",
       "item": "#input",
       "x": 30,
       "y": 8

--- a/test_guide/en_us/templates/crafting_arc.json
+++ b/test_guide/en_us/templates/crafting_arc.json
@@ -8,6 +8,12 @@
       "y": -6
     },
     {
+      "type": "text",
+      "text": "#text",
+      "x": 0,
+      "y": 51
+    },
+    {
       "type": "item",
       "item": "#fluid_input",
       "x": 6,


### PR DESCRIPTION
All crafting mechanics, Orbs, Slates, and Tartaric Gems are properly recipe linked.  When players hover over one of them in a recipe (and assuming it's not specified on the same entry), they can shift + click it to go to the relevant page for that crafting mechanic or item.  There is a tool-tip to indicate this ability.

Tweaked and added some Templates.  Altars now show the Altar item below the output (following Patchouli's standard), ARCs and Alchemy Tables gets a text box underneath them, and there are now 2x and 3x ARC crafting templates (using the nested template format).

Added proper entries for the Alchemy Table and ARC.  They can use writing polishing passes, and possibly format passes for things like colored text.

Added entry for Bloodstone Bricks to Utility.  Updated the Tier-4 Blood Altar page to link there.  Also ensured that Weak Blood Shards link to the relevant ARC page (Imbued Slate + Sanguine Reverter).  That should make it very clear on how to get a Tier-4 Altar.

Corrected Tier-3 Altar multiblock.

A few other minor tweaks.  Adding a few words here, changing a 5000 to 5k to match adjacent entries there, etc.

Added "VT_notes.txt" with several thoughts that came up which would be better addressed by or in communication with Wrince and/or WayofTime.